### PR TITLE
Fix build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,24 @@
-build: suica
+# Makefile
 
-suica: main.c
-	gcc -g -O0 -Wall -o $@ $^ -lpafe
+CC = gcc
+CFLAGS = -g -O2 -W -Wall
+LDFLAGS = -lpafe
 
+SUICA = suica
+SUICA_SRCS = main.c
+SUICA_OBJS = $(SUICA_SRCS:.c=.o)
+
+.PHONY: build
+build: $(SUICA)
+
+$(SUICA): $(SUICA_OBJS)
+	$(CC) -o $@ $(SUICA_OBJS) $(LDFLAGS)
+
+.SUFFIXES:
+.SUFFIXES: .c .o
+.c.o:
+	$(CC) $(CFLAGS) -o $@ -c $<
+
+.PHONY: clean
 clean:
-	rm -rf *.o *.dSYM suica
+	rm -rf $(SUICA) $(SUICA_OBJS) *.dSYM

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 build: suica
 
 suica: main.c
-	gcc -lpafe -g -O0 -Wall -o $@ $^
+	gcc -g -O0 -Wall -o $@ $^ -lpafe
 
 clean:
 	rm -rf *.o *.dSYM suica


### PR DESCRIPTION
リンカオプションの指定位置が原因で、ビルドできなかったので修正しました。
また clang 等のコンパイラでコンパイルできるように Makefile のビルドプロセスの一部を変数化しました。

よろしければ、マージお願いします。